### PR TITLE
refactor(database): clarify create/grant pipeline parameter types

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,24 +1,24 @@
-version: 2
+version: "2"
 run:
   timeout: 5m
   allow-parallel-runners: true
   go: "1.25"
-linters-settings:
-  gosec:
-    excludes:
-      - G402
-  staticcheck:
-    checks: ["all", "-SA5001"]
-  funlen:
-    lines: 80
-    statements: 70
-  revive:
-    rules:
-      - name: var-naming
-        arguments: [["ID"]]
 linters:
   # inverted configuration with `enable-all` and `disable` is not scalable during updates of golangci-lint
-  disable-all: true
+  default: none
+  settings:
+    gosec:
+      excludes:
+        - G402
+    staticcheck:
+      checks: ["all", "-SA5001"]
+    funlen:
+      lines: 80
+      statements: 70
+    revive:
+      rules:
+        - name: var-naming
+          arguments: [["ID"]]
   enable:
     - asciicheck
     - bodyclose
@@ -42,15 +42,14 @@ linters:
     - unparam
     - unused
     - whitespace
-
-issues:
-  exclude-rules:
-    - linters:
-        - typecheck
-      text: "file requires newer Go version"
-    - path: "_test\\.go"
-      linters:
-        - funlen
+  exclusions:
+    rules:
+      - linters:
+          - typecheck
+        text: "file requires newer Go version"
+      - path: "_test\\.go"
+        linters:
+          - funlen
 
   # don't enable:
   # - godox

--- a/database.go
+++ b/database.go
@@ -5,18 +5,19 @@ import (
 	"fmt"
 
 	A "github.com/IBM/fp-go/v2/array"
+	E "github.com/IBM/fp-go/v2/either"
 	fperrors "github.com/IBM/fp-go/v2/errors"
 	F "github.com/IBM/fp-go/v2/function"
-	IO "github.com/IBM/fp-go/v2/io"
 	IOE "github.com/IBM/fp-go/v2/ioeither"
 	O "github.com/IBM/fp-go/v2/option"
+	P "github.com/IBM/fp-go/v2/pair"
 	driver "github.com/arangodb/go-driver"
 	"github.com/urfave/cli/v3"
 )
 
 // CreateDatabase creates one or more databases with optional user and grants
 func CreateDatabase(_ context.Context, cmd *cli.Command) error {
-	return F.Pipe5(
+	output := F.Pipe6(
 		cmd,
 		connParamsFromCmd,
 		createArangoClient,
@@ -33,12 +34,29 @@ func CreateDatabase(_ context.Context, cmd *cli.Command) error {
 			}
 		}),
 		IOE.Chain(createDatabasePipeline),
-		foldIOE[F.Void],
+		toEither,
+		E.Fold(
+			func(err error) P.Pair[CreateDatabaseResult, error] {
+				var zero CreateDatabaseResult
+				return P.MakePair(zero, err)
+			},
+			func(result CreateDatabaseResult) P.Pair[CreateDatabaseResult, error] {
+				return P.MakePair[CreateDatabaseResult, error](result, nil)
+			},
+		),
 	)
+	if err := P.Second(output); err != nil {
+		return err
+	}
+
+	logCreateDatabaseOutcome(newLogger(cmd), P.First(output))
+	return nil
 }
 
 // createDatabasePipeline creates databases and optionally creates a user with grants.
-func createDatabasePipeline(p DatabaseParams) IOE.IOEither[error, F.Void] {
+func createDatabasePipeline(
+	p DatabaseParams,
+) IOE.IOEither[error, CreateDatabaseResult] {
 	return F.Pipe2(
 		F.Pipe1(
 			p.Databases,
@@ -55,8 +73,8 @@ func createDatabasePipeline(p DatabaseParams) IOE.IOEither[error, F.Void] {
 	)
 }
 
-// createSingleDatabase creates a single database if it doesn't exist, logs the result
-func createSingleDatabase(p SingleDBParams) IOE.IOEither[error, F.Void] {
+// createSingleDatabase creates a single database if needed and returns creation status.
+func createSingleDatabase(p SingleDBParams) IOE.IOEither[error, CreateSingleDBResult] {
 	return F.Pipe2(
 		IOE.TryCatchError(func() (bool, error) {
 			return p.Client.DatabaseExists(context.Background(), p.Dbname)
@@ -67,15 +85,15 @@ func createSingleDatabase(p SingleDBParams) IOE.IOEither[error, F.Void] {
 		IOE.Chain(F.Ternary(
 			F.Identity[bool],
 			F.Constant1[bool](
-				IOE.FromIO[error](logDatabaseExists(p.Logger, p.Dbname)),
+				IOE.Of[error](P.MakePair(false, p.Dbname)),
 			),
 			F.Constant1[bool](createDatabase(p)),
 		)),
 	)
 }
 
-// createDatabase creates a single database and logs the result
-func createDatabase(p SingleDBParams) IOE.IOEither[error, F.Void] {
+// createDatabase creates a single database and returns creation status.
+func createDatabase(p SingleDBParams) IOE.IOEither[error, CreateSingleDBResult] {
 	return F.Pipe2(
 		IOE.TryCatchError(func() (F.Void, error) {
 			_, err := p.Client.CreateDatabase(
@@ -88,31 +106,53 @@ func createDatabase(p SingleDBParams) IOE.IOEither[error, F.Void] {
 		IOE.MapLeft[F.Void](fperrors.OnError(
 			fmt.Sprintf("error creating database %s", p.Dbname),
 		)),
-		IOE.ChainFirstIOK[error](func(_ F.Void) IO.IO[F.Void] {
-			return logDatabaseCreated(p.Logger, p.Dbname)
+		IOE.Map[error](func(_ F.Void) CreateSingleDBResult {
+			return P.MakePair(true, p.Dbname)
 		}),
 	)
 }
 
 // maybeCreateUserAndGrant returns a Kleisli arrow that creates a user and
-// grants access if Username is non-empty, otherwise succeeds with F.VOID
-func maybeCreateUserAndGrant(p DatabaseParams) func([]F.Void) IOE.IOEither[error, F.Void] {
-	return F.Constant1[[]F.Void](F.Pipe2(
-		p.Username,
-		O.FromPredicate(func(s string) bool { return len(s) > 0 }),
-		O.Fold(
-			func() IOE.IOEither[error, F.Void] {
-				return IOE.Of[error](F.VOID)
-			},
-			func(_ string) IOE.IOEither[error, F.Void] {
-				return createUserAndGrant(p)
-			},
-		),
-	))
+// grants access if Username is non-empty, otherwise returns database outcomes.
+func maybeCreateUserAndGrant(
+	p DatabaseParams,
+) func([]CreateSingleDBResult) IOE.IOEither[error, CreateDatabaseResult] {
+	return func(
+		dbResults []CreateSingleDBResult,
+	) IOE.IOEither[error, CreateDatabaseResult] {
+		return F.Pipe2(
+			p.Username,
+			O.FromPredicate(func(s string) bool { return len(s) > 0 }),
+			O.Fold(
+				func() IOE.IOEither[error, CreateDatabaseResult] {
+					return IOE.Of[error](CreateDatabaseResult{
+						Databases: dbResults,
+					})
+				},
+				func(_ string) IOE.IOEither[error, CreateDatabaseResult] {
+					return F.Pipe1(
+						createUserAndGrant(p),
+						IOE.Map[error](func(
+							result P.Pair[CreateUserResult, []CreateGrantResult],
+						) CreateDatabaseResult {
+							userResult := P.First(result)
+							return CreateDatabaseResult{
+								Databases: dbResults,
+								User:      &userResult,
+								Grants:    P.Second(result),
+							}
+						}),
+					)
+				},
+			),
+		)
+	}
 }
 
-// createUserAndGrant creates a user if they don't exist, then grants access to all databases
-func createUserAndGrant(p DatabaseParams) IOE.IOEither[error, F.Void] {
+// createUserAndGrant creates/gets a user and grants access to all databases.
+func createUserAndGrant(
+	p DatabaseParams,
+) IOE.IOEither[error, P.Pair[CreateUserResult, []CreateGrantResult]] {
 	return F.Pipe3(
 		IOE.TryCatchError(func() (bool, error) {
 			return p.Client.UserExists(context.Background(), p.Username)
@@ -122,17 +162,18 @@ func createUserAndGrant(p DatabaseParams) IOE.IOEither[error, F.Void] {
 		)),
 		IOE.Chain(F.Ternary(
 			F.Identity[bool],
-			func(_ bool) IOE.IOEither[error, driver.User] {
-				return F.Pipe1(
+			func(_ bool) IOE.IOEither[error, CreateUserResult] {
+				return F.Pipe2(
 					IOE.TryCatchError(func() (driver.User, error) {
 						return p.Client.User(context.Background(), p.Username)
 					}),
 					IOE.MapLeft[driver.User](fperrors.OnError(
 						fmt.Sprintf("error fetching user %s", p.Username),
 					)),
+					IOE.Map[error](withCreateStatus(false)),
 				)
 			},
-			func(_ bool) IOE.IOEither[error, driver.User] {
+			func(_ bool) IOE.IOEither[error, CreateUserResult] {
 				return F.Pipe2(
 					IOE.TryCatchError(func() (driver.User, error) {
 						return p.Client.CreateUser(
@@ -144,15 +185,13 @@ func createUserAndGrant(p DatabaseParams) IOE.IOEither[error, F.Void] {
 					IOE.MapLeft[driver.User](fperrors.OnError(
 						fmt.Sprintf("error creating user %s", p.Username),
 					)),
-					IOE.ChainFirstIOK[error](
-						func(_ driver.User) IO.IO[F.Void] {
-							return logUserCreated(p.Logger, p.Username)
-						},
-					),
+					IOE.Map[error](withCreateStatus(true)),
 				)
 			},
 		)),
-		IOE.Chain(func(user driver.User) IOE.IOEither[error, F.Void] {
+		IOE.Chain(func(
+			userResult CreateUserResult,
+		) IOE.IOEither[error, P.Pair[CreateUserResult, []CreateGrantResult]] {
 			return F.Pipe2(
 				F.Pipe1(
 					p.Databases,
@@ -162,19 +201,23 @@ func createUserAndGrant(p DatabaseParams) IOE.IOEither[error, F.Void] {
 							Logger: p.Logger,
 							Dbname: dbname,
 							Grant:  p.Grant,
-							User:   user,
+							User:   P.Second(userResult),
 						}
 					}),
 				),
 				IOE.TraverseArraySeq(grantSingleDatabase),
-				IOE.MapTo[error, []F.Void](F.VOID),
+				IOE.Map[error](func(
+					grants []CreateGrantResult,
+				) P.Pair[CreateUserResult, []CreateGrantResult] {
+					return P.MakePair(userResult, grants)
+				}),
 			)
 		}),
 	)
 }
 
 // grantSingleDatabase grants access to a single database for a user
-func grantSingleDatabase(g GrantDBParams) IOE.IOEither[error, F.Void] {
+func grantSingleDatabase(g GrantDBParams) IOE.IOEither[error, CreateGrantResult] {
 	return F.Pipe2(
 		IOE.TryCatchError(func() (driver.Database, error) {
 			return g.Client.Database(
@@ -185,29 +228,28 @@ func grantSingleDatabase(g GrantDBParams) IOE.IOEither[error, F.Void] {
 		IOE.MapLeft[driver.Database](fperrors.OnError(
 			fmt.Sprintf("error getting database %s", g.Dbname),
 		)),
-		IOE.Chain(func(db driver.Database) IOE.IOEither[error, F.Void] {
-			return F.Pipe2(
-				IOE.TryCatchError(func() (F.Void, error) {
-					return F.VOID, g.User.SetDatabaseAccess(
+		IOE.Chain(func(
+			db driver.Database,
+		) IOE.IOEither[error, CreateGrantResult] {
+			return F.Pipe1(
+				IOE.TryCatchError(func() (CreateGrantResult, error) {
+					err := g.User.SetDatabaseAccess(
 						context.Background(),
 						db,
 						getGrant(g.Grant),
 					)
+					if err != nil {
+						var zero CreateGrantResult
+						return zero, err
+					}
+					return P.MakePair(g.Dbname, g.Grant), nil
 				}),
-				IOE.MapLeft[F.Void](fperrors.OnError(
+				IOE.MapLeft[CreateGrantResult](fperrors.OnError(
 					fmt.Sprintf(
 						"error granting access to database %s",
 						g.Dbname,
 					),
 				)),
-				IOE.ChainFirstIOK[error](func(_ F.Void) IO.IO[F.Void] {
-					return logGrantAccess(
-						g.Logger,
-						g.User.Name(),
-						g.Dbname,
-						g.Grant,
-					)
-				}),
 			)
 		}),
 	)

--- a/database.go
+++ b/database.go
@@ -1,4 +1,4 @@
-package main
+paaaackage main
 
 import (
 	"context"
@@ -17,42 +17,45 @@ import (
 
 // CreateDatabase creates one or more databases with optional user and grants
 func CreateDatabase(_ context.Context, cmd *cli.Command) error {
-	databases := cmd.StringSlice("database")
-	dbparams := DatabaseParams{
-		WithClient: WithClient{Logger: newLogger(cmd)},
-		Username:   cmd.String("user"),
-		Password:   cmd.String("password"),
-		Grant:      cmd.String("grant"),
-	}
-	return F.Pipe6(
+	return F.Pipe5(
 		cmd,
 		connParamsFromCmd,
 		createArangoClient,
 		IOE.Map[error](func(client driver.Client) DatabaseParams {
+			databases := cmd.StringSlice("database")
 			dbparams.Client = client
-			return dbparams
+			return DatabaseParams{
+				WithClient: WithClient{
+					Client: client,
+					Logger: newLogger(cmd),
+				},
+				Dbname:    "",
+				Username:  cmd.String("user"),
+				Password:  cmd.String("password"),
+				Grant:     cmd.String("grant"),
+				Databases: databases,
+			}
 		}),
-		IOE.Chain(func(p DatabaseParams) IOE.IOEither[error, F.Void] {
-			return F.Pipe2(
-				F.Pipe1(
-					databases,
-					A.Map(func(dbname string) DatabaseParams {
-						q := p
-						q.Dbname = dbname
-						return q
-					}),
-				),
-				IOE.TraverseArraySeq(createSingleDatabase),
-				IOE.Chain(optionalCreateUserAndGrant(UserGrantParams{
-					Params: p, Databases: databases,
-				})),
-			)
-		}),
-		toEither,
-		E.Fold(
-			F.Identity[error],
-			func(_ F.Void) error { return nil },
+		IOE.Chain(createDatabasePipeline),
+		foldIOE[F.Void],
+	)
+}
+
+// createDatabasePipeline creates databases and optionally creates a user with grants.
+func createDatabasePipeline(p DatabaseParams) IOE.IOEither[error, F.Void] {
+	return F.Pipe2(
+		F.Pipe1(
+			p.Databases,
+			A.Map(func(dbname string) DatabaseParams {
+				q := p
+				q.Dbname = dbname
+				return q
+			}),
 		),
+		IOE.TraverseArraySeq(createSingleDatabase),
+		IOE.Chain(optionalCreateUserAndGrant(UserGrantParams{
+			Params: p, Databases: p.Databases,
+		})),
 	)
 }
 

--- a/database.go
+++ b/database.go
@@ -21,17 +21,15 @@ func CreateDatabase(_ context.Context, cmd *cli.Command) error {
 		connParamsFromCmd,
 		createArangoClient,
 		IOE.Map[error](func(client driver.Client) DatabaseParams {
-			databases := cmd.StringSlice("database")
 			return DatabaseParams{
 				WithClient: WithClient{
 					Client: client,
 					Logger: newLogger(cmd),
 				},
-				Dbname:    "",
 				Username:  cmd.String("user"),
 				Password:  cmd.String("password"),
 				Grant:     cmd.String("grant"),
-				Databases: databases,
+				Databases: cmd.StringSlice("database"),
 			}
 		}),
 		IOE.Chain(createDatabasePipeline),
@@ -44,21 +42,21 @@ func createDatabasePipeline(p DatabaseParams) IOE.IOEither[error, F.Void] {
 	return F.Pipe2(
 		F.Pipe1(
 			p.Databases,
-			A.Map(func(dbname string) DatabaseParams {
-				q := p
-				q.Dbname = dbname
-				return q
+			A.Map(func(dbname string) SingleDBParams {
+				return SingleDBParams{
+					Client: p.Client,
+					Logger: p.Logger,
+					Dbname: dbname,
+				}
 			}),
 		),
 		IOE.TraverseArraySeq(createSingleDatabase),
-		IOE.Chain(optionalCreateUserAndGrant(UserGrantParams{
-			Params: p, Databases: p.Databases,
-		})),
+		IOE.Chain(maybeCreateUserAndGrant(p)),
 	)
 }
 
 // createSingleDatabase creates a single database if it doesn't exist, logs the result
-func createSingleDatabase(p DatabaseParams) IOE.IOEither[error, F.Void] {
+func createSingleDatabase(p SingleDBParams) IOE.IOEither[error, F.Void] {
 	return F.Pipe2(
 		IOE.TryCatchError(func() (bool, error) {
 			return p.Client.DatabaseExists(context.Background(), p.Dbname)
@@ -77,7 +75,7 @@ func createSingleDatabase(p DatabaseParams) IOE.IOEither[error, F.Void] {
 }
 
 // createDatabase creates a single database and logs the result
-func createDatabase(p DatabaseParams) IOE.IOEither[error, F.Void] {
+func createDatabase(p SingleDBParams) IOE.IOEither[error, F.Void] {
 	return F.Pipe2(
 		IOE.TryCatchError(func() (F.Void, error) {
 			_, err := p.Client.CreateDatabase(
@@ -96,26 +94,25 @@ func createDatabase(p DatabaseParams) IOE.IOEither[error, F.Void] {
 	)
 }
 
-// optionalCreateUserAndGrant returns a Kleisli arrow that creates a user and
+// maybeCreateUserAndGrant returns a Kleisli arrow that creates a user and
 // grants access if Username is non-empty, otherwise succeeds with F.VOID
-func optionalCreateUserAndGrant(g UserGrantParams) func([]F.Void) IOE.IOEither[error, F.Void] {
+func maybeCreateUserAndGrant(p DatabaseParams) func([]F.Void) IOE.IOEither[error, F.Void] {
 	return F.Constant1[[]F.Void](F.Pipe2(
-		g.Params.Username,
+		p.Username,
 		O.FromPredicate(func(s string) bool { return len(s) > 0 }),
 		O.Fold(
 			func() IOE.IOEither[error, F.Void] {
 				return IOE.Of[error](F.VOID)
 			},
 			func(_ string) IOE.IOEither[error, F.Void] {
-				return createUserAndGrant(g)
+				return createUserAndGrant(p)
 			},
 		),
 	))
 }
 
 // createUserAndGrant creates a user if they don't exist, then grants access to all databases
-func createUserAndGrant(g UserGrantParams) IOE.IOEither[error, F.Void] {
-	p := g.Params
+func createUserAndGrant(p DatabaseParams) IOE.IOEither[error, F.Void] {
 	return F.Pipe3(
 		IOE.TryCatchError(func() (bool, error) {
 			return p.Client.UserExists(context.Background(), p.Username)
@@ -158,11 +155,15 @@ func createUserAndGrant(g UserGrantParams) IOE.IOEither[error, F.Void] {
 		IOE.Chain(func(user driver.User) IOE.IOEither[error, F.Void] {
 			return F.Pipe2(
 				F.Pipe1(
-					g.Databases,
-					A.Map(func(dbname string) UserWithGrant {
-						q := p
-						q.Dbname = dbname
-						return UserWithGrant{Params: q, User: user}
+					p.Databases,
+					A.Map(func(dbname string) GrantDBParams {
+						return GrantDBParams{
+							Client: p.Client,
+							Logger: p.Logger,
+							Dbname: dbname,
+							Grant:  p.Grant,
+							User:   user,
+						}
 					}),
 				),
 				IOE.TraverseArraySeq(grantSingleDatabase),
@@ -173,38 +174,38 @@ func createUserAndGrant(g UserGrantParams) IOE.IOEither[error, F.Void] {
 }
 
 // grantSingleDatabase grants access to a single database for a user
-func grantSingleDatabase(u UserWithGrant) IOE.IOEither[error, F.Void] {
+func grantSingleDatabase(g GrantDBParams) IOE.IOEither[error, F.Void] {
 	return F.Pipe2(
 		IOE.TryCatchError(func() (driver.Database, error) {
-			return u.Params.Client.Database(
+			return g.Client.Database(
 				context.Background(),
-				u.Params.Dbname,
+				g.Dbname,
 			)
 		}),
 		IOE.MapLeft[driver.Database](fperrors.OnError(
-			fmt.Sprintf("error getting database %s", u.Params.Dbname),
+			fmt.Sprintf("error getting database %s", g.Dbname),
 		)),
 		IOE.Chain(func(db driver.Database) IOE.IOEither[error, F.Void] {
 			return F.Pipe2(
 				IOE.TryCatchError(func() (F.Void, error) {
-					return F.VOID, u.User.SetDatabaseAccess(
+					return F.VOID, g.User.SetDatabaseAccess(
 						context.Background(),
 						db,
-						getGrant(u.Params.Grant),
+						getGrant(g.Grant),
 					)
 				}),
 				IOE.MapLeft[F.Void](fperrors.OnError(
 					fmt.Sprintf(
 						"error granting access to database %s",
-						u.Params.Dbname,
+						g.Dbname,
 					),
 				)),
 				IOE.ChainFirstIOK[error](func(_ F.Void) IO.IO[F.Void] {
 					return logGrantAccess(
-						u.Params.Logger,
-						u.User.Name(),
-						u.Params.Dbname,
-						u.Params.Grant,
+						g.Logger,
+						g.User.Name(),
+						g.Dbname,
+						g.Grant,
 					)
 				}),
 			)

--- a/database.go
+++ b/database.go
@@ -1,11 +1,10 @@
-paaaackage main
+package main
 
 import (
 	"context"
 	"fmt"
 
 	A "github.com/IBM/fp-go/v2/array"
-	E "github.com/IBM/fp-go/v2/either"
 	fperrors "github.com/IBM/fp-go/v2/errors"
 	F "github.com/IBM/fp-go/v2/function"
 	IO "github.com/IBM/fp-go/v2/io"
@@ -23,7 +22,6 @@ func CreateDatabase(_ context.Context, cmd *cli.Command) error {
 		createArangoClient,
 		IOE.Map[error](func(client driver.Client) DatabaseParams {
 			databases := cmd.StringSlice("database")
-			dbparams.Client = client
 			return DatabaseParams{
 				WithClient: WithClient{
 					Client: client,

--- a/database.go
+++ b/database.go
@@ -127,6 +127,7 @@ func maybeCreateUserAndGrant(
 				func() IOE.IOEither[error, CreateDatabaseResult] {
 					return IOE.Of[error](CreateDatabaseResult{
 						Databases: dbResults,
+						HasUser:   false,
 					})
 				},
 				func(_ string) IOE.IOEither[error, CreateDatabaseResult] {
@@ -138,7 +139,8 @@ func maybeCreateUserAndGrant(
 							userResult := P.First(result)
 							return CreateDatabaseResult{
 								Databases: dbResults,
-								User:      &userResult,
+								HasUser:   true,
+								User:      userResult,
 								Grants:    P.Second(result),
 							}
 						}),

--- a/database_test.go
+++ b/database_test.go
@@ -6,10 +6,7 @@ import (
 	"os"
 	"testing"
 
-	A "github.com/IBM/fp-go/v2/array"
 	E "github.com/IBM/fp-go/v2/either"
-	F "github.com/IBM/fp-go/v2/function"
-	IOE "github.com/IBM/fp-go/v2/ioeither"
 	driver "github.com/arangodb/go-driver"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -126,9 +123,10 @@ func TestCreateSingleDatabaseNew(t *testing.T) {
 	require.NoError(err)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	p := DatabaseParams{
-		WithClient: WithClient{Client: client, Logger: logger},
-		Dbname:     "fptest_newdb",
+	p := SingleDBParams{
+		Client: client,
+		Logger: logger,
+		Dbname: "fptest_newdb",
 	}
 	result := toEither(createSingleDatabase(p))
 	require.True(E.IsRight(result), "createSingleDatabase should succeed for new database")
@@ -151,9 +149,10 @@ func TestCreateSingleDatabaseIdempotent(t *testing.T) {
 	require.NoError(err)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	p := DatabaseParams{
-		WithClient: WithClient{Client: client, Logger: logger},
-		Dbname:     "fptest_idempotentdb",
+	p := SingleDBParams{
+		Client: client,
+		Logger: logger,
+		Dbname: "fptest_idempotentdb",
 	}
 	r1 := toEither(createSingleDatabase(p))
 	require.True(E.IsRight(r1))
@@ -181,16 +180,14 @@ func TestGrantSingleDatabase(t *testing.T) {
 	require.NoError(err)
 
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
-	uwg := UserWithGrant{
-		Params: DatabaseParams{
-			WithClient: WithClient{Client: client, Logger: logger},
-			Grant:      "rw",
-			Username:   "fptest_grantusr",
-			Dbname:     "fptest_grantdb",
-		},
-		User: user,
+	g := GrantDBParams{
+		Client: client,
+		Logger: logger,
+		Dbname: "fptest_grantdb",
+		Grant:  "rw",
+		User:   user,
 	}
-	result := toEither(grantSingleDatabase(uwg))
+	result := toEither(grantSingleDatabase(g))
 	require.True(E.IsRight(result), "grantSingleDatabase should succeed")
 }
 
@@ -211,24 +208,12 @@ func TestCreateDatabasePipelineWithUser(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(os.Stderr, nil))
 	p := DatabaseParams{
 		WithClient: WithClient{Client: client, Logger: logger},
+		Databases:  databases,
 		Username:   "fptest_grantuser",
 		Password:   "pass",
 		Grant:      "rw",
 	}
-	result := toEither(F.Pipe2(
-		F.Pipe1(
-			databases,
-			A.Map(func(dbname string) DatabaseParams {
-				q := p
-				q.Dbname = dbname
-				return q
-			}),
-		),
-		IOE.TraverseArraySeq(createSingleDatabase),
-		IOE.Chain(optionalCreateUserAndGrant(UserGrantParams{
-			Params: p, Databases: databases,
-		})),
-	))
+	result := toEither(createDatabasePipeline(p))
 	require.True(E.IsRight(result), "database pipeline should succeed")
 
 	// Verify databases exist

--- a/logger.go
+++ b/logger.go
@@ -62,11 +62,11 @@ func logCreateDatabaseOutcome(logger *slog.Logger, result CreateDatabaseResult) 
 		)
 	}
 
-	if result.User == nil {
+	if !result.HasUser {
 		return
 	}
 
-	logCreateUserOutcome(logger, *result.User)
+	logCreateUserOutcome(logger, result.User)
 }
 
 func statusFromCreated(created bool) string {

--- a/logger.go
+++ b/logger.go
@@ -48,20 +48,54 @@ func logUserCreated(logger *slog.Logger, username string) IO.IO[F.Void] {
 }
 
 func logCreateUserOutcome(logger *slog.Logger, result CreateUserResult) {
-	status := F.Pipe2(
-		P.First(result),
-		O.FromPredicate(F.Identity[bool]),
-		O.Fold(
-			func() string { return "existing" },
-			func(_ bool) string { return "created" },
-		),
-	)
+	status := statusFromCreated(P.First(result))
 	logger.Info(
 		"user status",
 		"username",
 		P.Second(result).Name(),
 		"status",
 		status,
+	)
+}
+
+func logCreateDatabaseOutcome(logger *slog.Logger, result CreateDatabaseResult) {
+	for _, dbResult := range result.Databases {
+		logger.Info(
+			"database status",
+			"database",
+			P.Second(dbResult),
+			"status",
+			statusFromCreated(P.First(dbResult)),
+		)
+	}
+
+	if result.User == nil {
+		return
+	}
+
+	logCreateUserOutcome(logger, *result.User)
+	username := P.Second(*result.User).Name()
+	for _, grantResult := range result.Grants {
+		logger.Info(
+			"database access granted",
+			"username",
+			username,
+			"database",
+			P.First(grantResult),
+			"grant",
+			P.Second(grantResult),
+		)
+	}
+}
+
+func statusFromCreated(created bool) string {
+	return F.Pipe2(
+		created,
+		O.FromPredicate(F.Identity[bool]),
+		O.Fold(
+			func() string { return "existing" },
+			func(_ bool) string { return "created" },
+		),
 	)
 }
 

--- a/logger.go
+++ b/logger.go
@@ -67,18 +67,6 @@ func logCreateDatabaseOutcome(logger *slog.Logger, result CreateDatabaseResult) 
 	}
 
 	logCreateUserOutcome(logger, *result.User)
-	username := P.Second(*result.User).Name()
-	for _, grantResult := range result.Grants {
-		logger.Info(
-			"database access granted",
-			"username",
-			username,
-			"database",
-			P.First(grantResult),
-			"grant",
-			P.Second(grantResult),
-		)
-	}
 }
 
 func statusFromCreated(created bool) string {

--- a/logger.go
+++ b/logger.go
@@ -40,13 +40,6 @@ func parseLogLevel(levelStr string) slog.Level {
 	}
 }
 
-func logUserCreated(logger *slog.Logger, username string) IO.IO[F.Void] {
-	return func() F.Void {
-		logger.Info("user status", "username", username, "status", "created")
-		return F.VOID
-	}
-}
-
 func logCreateUserOutcome(logger *slog.Logger, result CreateUserResult) {
 	status := statusFromCreated(P.First(result))
 	logger.Info(
@@ -102,38 +95,6 @@ func statusFromCreated(created bool) string {
 func logUserUpdated(logger *slog.Logger, username string) IO.IO[F.Void] {
 	return func() F.Void {
 		logger.Info("user status", "username", username, "status", "updated")
-		return F.VOID
-	}
-}
-
-func logDatabaseCreated(logger *slog.Logger, dbname string) IO.IO[F.Void] {
-	return func() F.Void {
-		logger.Info("database created", "database", dbname)
-		return F.VOID
-	}
-}
-
-func logDatabaseExists(logger *slog.Logger, dbname string) IO.IO[F.Void] {
-	return func() F.Void {
-		logger.Info("database exists", "database", dbname)
-		return F.VOID
-	}
-}
-
-func logGrantAccess(
-	logger *slog.Logger,
-	username, dbname, grant string,
-) IO.IO[F.Void] {
-	return func() F.Void {
-		logger.Info(
-			"database access granted",
-			"username",
-			username,
-			"database",
-			dbname,
-			"grant",
-			grant,
-		)
 		return F.VOID
 	}
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -120,3 +120,38 @@ func TestLogUserUpdatedIncludesStatus(t *testing.T) {
 	require.Contains(output, "username=updated-user")
 	require.Contains(output, "status=updated")
 }
+
+func TestLogCreateDatabaseOutcomeIncludesStatuses(t *testing.T) {
+	require := require.New(t)
+	var buf bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&buf, nil))
+
+	userResult := P.MakePair[bool, driver.User](true, testUser{
+		name:   "db-user",
+		active: true,
+	})
+	result := CreateDatabaseResult{
+		Databases: []CreateSingleDBResult{
+			P.MakePair(true, "db_created"),
+			P.MakePair(false, "db_existing"),
+		},
+		User: &userResult,
+		Grants: []CreateGrantResult{
+			P.MakePair("db_created", "rw"),
+			P.MakePair("db_existing", "rw"),
+		},
+	}
+
+	logCreateDatabaseOutcome(logger, result)
+	output := buf.String()
+
+	require.Contains(output, "msg=\"database status\"")
+	require.Contains(output, "database=db_created")
+	require.Contains(output, "status=created")
+	require.Contains(output, "database=db_existing")
+	require.Contains(output, "status=existing")
+	require.Contains(output, "msg=\"user status\"")
+	require.Contains(output, "username=db-user")
+	require.Contains(output, "msg=\"database access granted\"")
+	require.Contains(output, "grant=rw")
+}

--- a/logger_test.go
+++ b/logger_test.go
@@ -152,6 +152,4 @@ func TestLogCreateDatabaseOutcomeIncludesStatuses(t *testing.T) {
 	require.Contains(output, "status=existing")
 	require.Contains(output, "msg=\"user status\"")
 	require.Contains(output, "username=db-user")
-	require.Contains(output, "msg=\"database access granted\"")
-	require.Contains(output, "grant=rw")
 }

--- a/logger_test.go
+++ b/logger_test.go
@@ -135,7 +135,8 @@ func TestLogCreateDatabaseOutcomeIncludesStatuses(t *testing.T) {
 			P.MakePair(true, "db_created"),
 			P.MakePair(false, "db_existing"),
 		},
-		User: &userResult,
+		HasUser: true,
+		User:    userResult,
 		Grants: []CreateGrantResult{
 			P.MakePair("db_created", "rw"),
 			P.MakePair("db_existing", "rw"),

--- a/types.go
+++ b/types.go
@@ -8,7 +8,7 @@ import (
 	"github.com/urfave/cli/v3"
 )
 
-// Base connection params (parsed from CLI flags)
+// ConnectionParams contains connection values parsed from CLI flags.
 type ConnectionParams struct {
 	Host, Port, User, Pass string
 	IsSecure               bool
@@ -20,14 +20,14 @@ type WithConnection struct {
 	Conn driver.Connection
 }
 
-// Enriched with ArangoDB client + logger
+// WithClient enriches connection params with an ArangoDB client and logger.
 type WithClient struct {
 	ConnectionParams
 	Client driver.Client
 	Logger *slog.Logger
 }
 
-// --- create-user / update-user ---
+// UserParams contains CLI-provided user values plus client dependencies.
 type UserParams struct {
 	WithClient
 	Username, Password string
@@ -45,7 +45,7 @@ type CreateUserResult = P.Pair[bool, driver.User]
 // CreateUserRouteParams carries user existence state alongside create-user params.
 type CreateUserRouteParams = P.Pair[bool, CreateUserParams]
 
-// --- create-database ---
+// DatabaseParams contains create-database command inputs and dependencies.
 type DatabaseParams struct {
 	WithClient
 	Databases          []string
@@ -79,7 +79,8 @@ type CreateGrantResult = P.Pair[string, string]
 // and grants applied during create-database command execution.
 type CreateDatabaseResult struct {
 	Databases []CreateSingleDBResult
-	User      *CreateUserResult
+	HasUser   bool
+	User      CreateUserResult
 	Grants    []CreateGrantResult
 }
 

--- a/types.go
+++ b/types.go
@@ -49,6 +49,7 @@ type CreateUserRouteParams = P.Pair[bool, CreateUserParams]
 type DatabaseParams struct {
 	WithClient
 	Dbname             string
+	Databases          []string
 	Username, Password string // optional user creation
 	Grant              string
 }

--- a/types.go
+++ b/types.go
@@ -69,6 +69,20 @@ type GrantDBParams struct {
 	User   driver.User
 }
 
+// CreateSingleDBResult carries whether a database was newly created and its name.
+type CreateSingleDBResult = P.Pair[bool, string]
+
+// CreateGrantResult carries database name and applied grant.
+type CreateGrantResult = P.Pair[string, string]
+
+// CreateDatabaseResult carries outcomes for database creation, optional user creation,
+// and grants applied during create-database command execution.
+type CreateDatabaseResult struct {
+	Databases []CreateSingleDBResult
+	User      *CreateUserResult
+	Grants    []CreateGrantResult
+}
+
 // Pure helper to extract connection params from CLI
 func connParamsFromCmd(cmd *cli.Command) ConnectionParams {
 	return ConnectionParams{

--- a/types.go
+++ b/types.go
@@ -48,21 +48,24 @@ type CreateUserRouteParams = P.Pair[bool, CreateUserParams]
 // --- create-database ---
 type DatabaseParams struct {
 	WithClient
-	Dbname             string
 	Databases          []string
 	Username, Password string // optional user creation
 	Grant              string
 }
 
-// Intermediate type for optional user creation + grant pipeline
-type UserGrantParams struct {
-	Params    DatabaseParams
-	Databases []string
+// SingleDBParams carries what's needed to create one database
+type SingleDBParams struct {
+	Client driver.Client
+	Logger *slog.Logger
+	Dbname string
 }
 
-// Intermediate type for create-database grant pipeline
-type UserWithGrant struct {
-	Params DatabaseParams
+// GrantDBParams carries what's needed to grant a user access to one database
+type GrantDBParams struct {
+	Client driver.Client
+	Logger *slog.Logger
+	Dbname string
+	Grant  string
 	User   driver.User
 }
 


### PR DESCRIPTION
## Summary
Refactor the database creation flow by introducing focused parameter types for each pipeline stage. This improves type safety and makes stage responsibilities explicit.

## What changed
- Replaced broad create-database input usage with stage-specific structs.
- Introduced:
  - `SingleDBParams` for per-database creation inputs
  - `GrantDBParams` for per-database grant inputs
- Updated pipeline mapping so shared inputs are transformed explicitly before each stage.
- Renamed helper `optionalCreateUserAndGrant` to `maybeCreateUserAndGrant` for clearer intent.
- Updated tests to align with new parameter types and pipeline signatures.

## Why
The previous parameter shape mixed concerns across pipeline steps. Splitting create/grant parameters makes the data flow easier to reason about and reduces accidental misuse.

## Validation
- Verified package compilation with `go test ./... -run '^$'`.
