### PR TITLE
fix(docker): update COPY and build path for cmd/arangoadmin layout

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,11 +13,12 @@ WORKDIR /arangoadmin
 COPY go.mod go.sum ./
 RUN go mod download
 
-COPY *.go ./
+COPY . .
 
 RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build \
 	-ldflags "-s -w" \
-	-o /bin/app
+	-o /bin/app \
+	./cmd/arangoadmin/
 
 RUN upx -q -9 /bin/app
 


### PR DESCRIPTION
## Summary

- Replace `COPY *.go ./` with `COPY . .` to include `cmd/` and `internal/` directories
- Add `./cmd/arangoadmin/` package path to `go build` now that the entrypoint moved out of the root

## Test plan

- [ ] `docker buildx build` succeeds for `linux/amd64`
- [ ] `docker buildx build` succeeds for `linux/arm64`

🤖 Generated with [Claude Code](https://claude.com/claude-code)